### PR TITLE
If no flavorAppId defined then fallback to defaultConfig one

### DIFF
--- a/src/main/groovy/com/trifork/tpa/task/AbstractTpaTask.groovy
+++ b/src/main/groovy/com/trifork/tpa/task/AbstractTpaTask.groovy
@@ -107,7 +107,9 @@ abstract class AbstractTpaTask extends DefaultTask {
             }
             return project.android.defaultConfig.applicationId
         }else{
-            return project.android.productFlavors[productFlavor].applicationId
+            def flavouredAppId = project.android.productFlavors[productFlavor].applicationId
+            def defaultAppId = project.android.defaultConfig.applicationId
+            return flavouredAppId != null ? flavouredAppId : defaultAppId
         }
     }
     


### PR DESCRIPTION
When using flavors in the gradle buildscript if no applicationId was defined on the flavor this plugin returns `null` as the `applicationId` field. 

This PR's objective is to fix that by a simply `null` checking the flavoured `applicationId` and if it's `null` then return the `applicationId` from the `defaultConfig`.